### PR TITLE
imp-26-raycast-dist

### DIFF
--- a/rayCaster.h
+++ b/rayCaster.h
@@ -15,10 +15,10 @@ namespace vb01{
 				Mesh *mesh = nullptr;
 			};
 
-			static std::vector<CollisionResult> cast(Vector3, Vector3, Node*, const float = .0);
-			static std::vector<CollisionResult> cast(Vector3, Vector3, std::vector<Node*>, const float = .0);
+			static std::vector<CollisionResult> cast(Vector3, Vector3, Node*, const float = .0, const float = .0);
+			static std::vector<CollisionResult> cast(Vector3, Vector3, std::vector<Node*>, const float = .0, const float = .0);
 		private:
-			static std::vector<CollisionResult> retrieveCollisions(Vector3, Vector3, Node*, const float);
+			static std::vector<CollisionResult> retrieveCollisions(Vector3, Vector3, Node*, const float, const float);
 			static void sortResults(std::vector<CollisionResult>&);
 	};
 


### PR DESCRIPTION
Mesh vertices are now checked if they're within a certain distance from cast rays (if `distToRay` is higher than 0)
Steps to test: see [https://github.com/devZoGok/Battleship/pull/57](url)