### PR TITLE
Bf 34 hide complex nodes

### DIFF
--- a/node.cpp
+++ b/node.cpp
@@ -43,7 +43,17 @@ namespace vb01{
 	}
 
 	void Node::update(){
-		if(visible){
+		bool render = true;
+		Node *ancestor = this;
+
+		while(ancestor){
+			render = ancestor->isVisible();
+			ancestor = ancestor->getParent();
+
+			if(!render) break;
+		}
+
+		if(render){
 			for(Light *l : lights)
 				l->update();
 


### PR DESCRIPTION
Fixed not being able to hide complex nodes. Steps to test:
1) load a model
2) run `setVisible(false)`
3) observe the model not be rendered